### PR TITLE
More like this

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -69,6 +69,15 @@ facet input is:
 
 For more details about the options that can be used see the [Search parameters](search-parameters.md#facets) page.
 
+### More Like This
+The More Like This input allows us to specify the id of the document we want to obtain similar results from as well as 
+the fields that we want to use for comparison.
+
+* id - The id of the Search API document to use for comparison.
+* fields - The fields to be used for the More Like This feature to retrieve similar items.
+
+For more details about the options that can be used see the [Search parameters](search-parameters.md#more-like-this) page.
+
 ### Fulltext
 The Fulltext input allows us to specify fulltext arguments in our search query.
 

--- a/docs/search-parameters.md
+++ b/docs/search-parameters.md
@@ -233,6 +233,32 @@ Returns the all documents in the index and the facet values (and counts) for the
   }
 }
 ```
+## More Like This
+The More Like This argument can be used to obtain a list of similar documents to the one supplied based on a list of 
+fields for comparison (See [Apache Solr Documentation](https://lucene.apache.org/solr/guide/6_6/morelikethis.html) for 
+an example of the Solr implementation).
+ 
+ | Argument  | Required | Type   | Values                                                                                                                                                                                                                              |
+ |-----------|----------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+ | `id` | yes      | `String` | The Search API ID of the document to use as source.                                                     |
+ | `fields`     | yes      | `[String]` | A list of fields to be used for the comparison. |
+ 
+### Example 
+Returns all 'article' documents similar to the document with id (nid) 4 based on the study field and article type.
+
+```
+{
+  searchAPISearch(index_id: "index_name", conditions: {name: "node_type", value: "article", operator: "="}, more_like_this: {id: "4", fields: ["article_type_fulltext", "study_field_fulltext"]}) {
+    documents {
+      index_id
+      ... on IndexNameDoc {
+        title
+        body
+      }
+    }
+  }
+}
+```
 
 ## Solr Parameters (Apache Solr Only)
 This special type parameter is only applicable to Apache Solr. It allows us to specify raw Solr query parameters such as

--- a/src/Plugin/GraphQL/Fields/SearchAPISearch.php
+++ b/src/Plugin/GraphQL/Fields/SearchAPISearch.php
@@ -204,10 +204,10 @@ class SearchAPISearch extends FieldPluginBase {
     // Retrieve this index server details.
     $server = $this->index->getServerInstance();
 
-    // Check if the index server supports facets (e.g solr).
+    // Check if the index server supports More Like This (e.g solr).
     if ($server->supportsFeature('search_api_mlt')) {
 
-      // Set the facets in the query.
+      // Set the more like this parameters in the query.
       $this->query->setOption('search_api_mlt', $mlt_params);
     }
   }
@@ -257,7 +257,7 @@ class SearchAPISearch extends FieldPluginBase {
     if ($args['facets']) {
       $this->setFacets($args['facets']);
     }
-    // Adding facets to the query.
+    // Adding more like this parameters to the query.
     if ($args['more_like_this']) {
       $this->setMLT($args['more_like_this']);
     }

--- a/src/Plugin/GraphQL/Fields/SearchAPISearch.php
+++ b/src/Plugin/GraphQL/Fields/SearchAPISearch.php
@@ -26,6 +26,7 @@ use Drupal\search_api\Entity\Index;
  *     "range" = "RangeInput",
  *     "sort" = "SortInput",
  *     "facets" = "[FacetInput]",
+ *     "more_like_this" = "MLTInput",
  *     "solr_params" = "[SolrParameterInput]",
  *   },
  * )
@@ -193,6 +194,25 @@ class SearchAPISearch extends FieldPluginBase {
   }
 
   /**
+   * Sets MLT in the Search API query.
+   *
+   * @facets
+   *  The MLT params to be added to the query.
+   */
+  private function setMLT($mlt_params) {
+
+    // Retrieve this index server details.
+    $server = $this->index->getServerInstance();
+
+    // Check if the index server supports facets (e.g solr).
+    if ($server->supportsFeature('search_api_mlt')) {
+
+      // Set the facets in the query.
+      $this->query->setOption('search_api_mlt', $mlt_params);
+    }
+  }
+
+  /**
    * Prepares the Search API query by adding all possible options.
    *
    * Options include conditions, language, fulltext, range, sort and facets.
@@ -236,6 +256,10 @@ class SearchAPISearch extends FieldPluginBase {
     // Adding facets to the query.
     if ($args['facets']) {
       $this->setFacets($args['facets']);
+    }
+    // Adding facets to the query.
+    if ($args['more_like_this']) {
+      $this->setMLT($args['more_like_this']);
     }
   }
 

--- a/src/Plugin/GraphQL/InputTypes/MLTInput.php
+++ b/src/Plugin/GraphQL/InputTypes/MLTInput.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\graphql_search_api\Plugin\GraphQL\InputTypes;
+
+use Drupal\graphql\Plugin\GraphQL\InputTypes\InputTypePluginBase;
+
+/**
+ * More Like This input type.
+ *
+ * @GraphQLInputType(
+ *   id = "MLTInput",
+ *   name = "MLTInput",
+ *   fields = {
+ *     "id" = "String!",
+ *     "fields" = "[String]!",
+ *   }
+ * )
+ */
+class MLTInput extends InputTypePluginBase {
+
+}


### PR DESCRIPTION
@joaogarin This PR adds support for More Like This.
This feature allows you to obtain a list of "similar" or "related" items of a document (see https://lucene.apache.org/solr/guide/6_6/morelikethis.html for the Solr implementation).