### PR TITLE
Adding keys as an array and the option to specify a conjunction.

### DIFF
--- a/src/Plugin/GraphQL/Fields/SearchAPISearch.php
+++ b/src/Plugin/GraphQL/Fields/SearchAPISearch.php
@@ -151,7 +151,18 @@ class SearchAPISearch extends FieldPluginBase {
    */
   private function setFulltextFields($full_text_params) {
 
-    // Set the mandatory keys in the query.
+    // Check if keys is an array and if so set a conjunction.
+    if (is_array($full_text_params['keys'])) {
+      // If no conjunction was specified use OR as default.
+      if ($full_text_params['conjunction']) {
+        $full_text_params['keys']['#conjunction'] = $full_text_params['conjunction'];
+      }
+      else {
+        $full_text_params['keys']['#conjunction'] = 'OR';
+      }
+    }
+
+    // Set the keys in the query.
     $this->query->keys($full_text_params['keys']);
 
     // Set the optional fulltext fields if specified.

--- a/src/Plugin/GraphQL/InputTypes/FulltextInput.php
+++ b/src/Plugin/GraphQL/InputTypes/FulltextInput.php
@@ -11,8 +11,9 @@ use Drupal\graphql\Plugin\GraphQL\InputTypes\InputTypePluginBase;
  *   id = "fulltextInput",
  *   name = "FulltextInput",
  *   fields = {
- *     "keys" = "String!",
+ *     "keys" = "[String]!",
  *     "fields" = "[String]",
+ *     "conjunction" = "String",
  *   }
  * )
  */


### PR DESCRIPTION
@joaogarin This feature allows us to specify multiple keys for fulltext search.
Currently you can only specify a keyword string. So if you want to do a query like "Find me all results that match 'this' or 'that' you can't. This PR adds the ability to specify an array of keywords and an optional conjunction parameter.

Examples:

- If you want all jobs that match "Engineering" OR "Finance" in a set of fields you can specify the array of keys and OR as conjunction (or ommit it since it's default).
- If you want all jobs that match "Engineering" AND "Computers" in a set of fields you can specify the array of keys and AND as conjunction. (It will only match if there are fields that find both keywords inside that field value).