### PR TITLE
fix(SearchAPISearch): Fix field check for conjunction

### DIFF
--- a/src/Plugin/GraphQL/Fields/SearchAPISearch.php
+++ b/src/Plugin/GraphQL/Fields/SearchAPISearch.php
@@ -162,7 +162,7 @@ class SearchAPISearch extends FieldPluginBase {
     // Check if keys is an array and if so set a conjunction.
     if (is_array($full_text_params['keys'])) {
       // If no conjunction was specified use OR as default.
-      if ($full_text_params['conjunction']) {
+      if (!empty($full_text_params['conjunction'])) {
         $full_text_params['keys']['#conjunction'] = $full_text_params['conjunction'];
       }
       else {


### PR DESCRIPTION
This is throwing an error on our sites, I think the check might not work just as is as if the property is not there at all its going to error out.

<img width="1383" alt="screen shot 2018-11-09 at 09 41 14" src="https://user-images.githubusercontent.com/2866604/48255111-a3dcee00-e403-11e8-972a-37396b1ab1d1.png">
