### PR TITLE
Issue #21 by bucefal91: Making sure the graphql API handles correctly…

### DIFF
--- a/src/Plugin/GraphQL/Fields/SearchAPISearch.php
+++ b/src/Plugin/GraphQL/Fields/SearchAPISearch.php
@@ -434,7 +434,7 @@ class SearchAPISearch extends FieldPluginBase implements ContainerFactoryPluginI
         }
       }
       // Load the value in the response document.
-      if (!empty($value)) {
+      if (!is_null($value)) {
         $response_document[$field_id] = $value;
       }
     }


### PR DESCRIPTION
This is PR that fixes https://github.com/drupal-graphql/graphql-search-api/issues/21

I am simply using `is_null()` instead of `empty()` which yields a bit stricter match against NULLness without affecting such values as `(string) ""` or `(int) 0`.

After applying this patch and clearing the cache on the same solr index my graphql now responds zeros as it should:
![Screenshot from 2019-07-13 12-56-44](https://user-images.githubusercontent.com/17630965/61175080-2c9dc200-a56f-11e9-93ae-b18c9f33f6d5.png)
