### PR TITLE
Introducing a dedicated permission per each search API index so query…

### DIFF
--- a/graphql_search_api.module
+++ b/graphql_search_api.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * A Search API GraphQL schema.
+ */
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\graphql_search_api\GraphqlSearchApiPermission;
+
+/**
+ * Implements hook_ENTITY_TYPE_access().
+ */
+function graphql_search_api_search_api_index_access(EntityInterface $entity, $operation, AccountInterface $account) {
+  $access = AccessResult::neutral();
+
+  if ($operation == 'graphql_search_api_query') {
+    $access = AccessResult::allowedIfHasPermission($account, GraphqlSearchApiPermission::getPermissionName($entity));
+  }
+
+  return $access;
+}

--- a/graphql_search_api.permissions.yml
+++ b/graphql_search_api.permissions.yml
@@ -1,0 +1,2 @@
+permission_callbacks:
+  - \Drupal\graphql_search_api\GraphqlSearchApiPermission::getPermissions

--- a/src/GraphqlSearchApiPermission.php
+++ b/src/GraphqlSearchApiPermission.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\graphql_search_api;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\search_api\Entity\Index;
+use Drupal\search_api\IndexInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides dynamic permissions for search API indexes.
+ */
+class GraphqlSearchApiPermission implements ContainerInjectionInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * GraphqlSearchApiPermission constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static($container->get('entity_type.manager'));
+  }
+
+  /**
+   * Returns an array of index permissions.
+   *
+   * @return array
+   *   The search api index permissions.
+   */
+  public function getPermissions() {
+    $permissions = [];
+
+    foreach ($this->entityTypeManager->getStorage('search_api_index')->loadMultiple() as $index) {
+      $permissions += [
+        self::getPermissionName($index) => [
+          'title' => $this->t('Execute GraphQL query against @index search index', [
+            '@index' => $index->label(),
+          ]),
+          'description' => $this->t('Allows user to execute arbitrary GraphQL queries against the @index Search API index. Therefore contents of the @index Search API index will be available to users with this permission via GraphQL queries.', [
+            '@index' => $index->label(),
+          ]),
+        ],
+      ];
+    }
+
+    return $permissions;
+  }
+
+  /**
+   * Assemble permission name that allows querying Search API index in GraphQL.
+   *
+   * @param \Drupal\search_api\IndexInterface $index
+   *   Search API index whose permission name to assemble.
+   *
+   * @return string
+   *   Permission name that allows executing GraphQL queries against the
+   *   supplied Search API index.
+   */
+  public static function getPermissionName(IndexInterface $index) {
+    return "execute graphql requests {$index->id()} index";
+  }
+
+}

--- a/src/Plugin/GraphQL/Fields/SearchAPISearch.php
+++ b/src/Plugin/GraphQL/Fields/SearchAPISearch.php
@@ -81,6 +81,14 @@ class SearchAPISearch extends FieldPluginBase implements ContainerFactoryPluginI
     // Load up the index passed in argument.
     $this->index = $this->entityTypeManager->getStorage('search_api_index')->load($args['index_id']);
 
+    $access = $this->index->access('graphql_search_api_query', NULL, TRUE);
+
+    $resolved_value = new CacheableValue(NULL, [$access]);
+    if (!$access->isAllowed()) {
+      yield $resolved_value;
+      return;
+    }
+
     // Prepare the query with our arguments.
     $this->prepareSearchQuery($args);
 
@@ -102,7 +110,8 @@ class SearchAPISearch extends FieldPluginBase implements ContainerFactoryPluginI
     // Set response type.
     $search_response['type'] = 'SearchAPIResult';
 
-    yield $search_response;
+    $resolved_value->setValue($search_response);
+    yield $resolved_value;
 
   }
 


### PR DESCRIPTION
We have been using this module pretty successfully. In fact, it helps us expose 3 search API indexes over GraphQL api for our front end JS code.

However, only 2 of those 3 indexes are supposed to be public and the third may not be freely given access to. So we need some kind of per-index/per-role granularity there. This PR seeks to achieve this goal.

First of all, it introduces a dedicated permission per each Search API index that implies granting access to query it over graphql api. And then it adjusts the logic in the SearchApiSearch PHP class so it actively queries index for access before proceeding further. I made the access check to go via `$index->access()` so other modules, in case they have any opinion may provide their own access logic (in case just a plain permission per index is not enough).

:) I've tested it and works like a charm for us :) The only thing is that apparently breaks the backwards compatibility since now users need an explicit extra permission and before the access was simply implied there. But maybe introducing a global 'execute graphql requests on search api indexes' + an update hook that will grant this permission to all roles is enough to catch up on the backwards compatibility? :) 