### PR TITLE
Add core_version_requirement to make this module D9 ready

### DIFF
--- a/graphql_search_api.info.yml
+++ b/graphql_search_api.info.yml
@@ -2,6 +2,7 @@ name: Graphql Search API
 type: module
 description: A Search API GraphQL schema.
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: Search
 dependencies:
   - graphql


### PR DESCRIPTION
Upgrade status reported only 1 warning:

`Add core_version_requirement: ^8 || ^9 to designate that the module is compatible with Drupal 9. See https://drupal.org/node/3070687.`

Please, kindly review the small PR :) 