### PR TITLE
Fix Notice: Undefined index: operator in addConditionGroup

### DIFF
--- a/src/Plugin/GraphQL/Fields/SearchAPISearch.php
+++ b/src/Plugin/GraphQL/Fields/SearchAPISearch.php
@@ -169,7 +169,7 @@ class SearchAPISearch extends FieldPluginBase implements ContainerFactoryPluginI
       // Loop through all conditions and add them to the Group.
       foreach ($group['conditions'] as $condition) {
 
-        $condition_group->addCondition($condition['name'], $condition['value'], $condition['operator']);
+        $condition_group->addCondition($condition['name'], $condition['value'] ?? NULL, $condition['operator'] ?? '=');
       }
 
       // Merge the single groups to the condition group.


### PR DESCRIPTION
When executing queries with ConditionGroup, that doesn't contain operator (that is not required), Drupal shows the notice:
```
Notice: Undefined index: operator in Drupal\graphql_search_api\Plugin\GraphQL\Fields\SearchAPISearch->addConditionGroup() (line 172 of web/modules/contrib/graphql_search_api/src/Plugin/GraphQL/Fields/SearchAPISearch.php).
```
Here is fix for this notice. Instead of `if` checking, I use the `??` construction, that must be available in PHP 7.0+

Also `value` may be not required too (for example, if operator = "IS_NULL"), so I add `NULL` replacement to it.