### PR TITLE
Modify field derivative IDs to include index

### DIFF
--- a/src/Plugin/GraphQL/Derivers/SearchAPIFieldDeriver.php
+++ b/src/Plugin/GraphQL/Derivers/SearchAPIFieldDeriver.php
@@ -6,6 +6,7 @@ use Drupal\Component\Plugin\Derivative\DeriverBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\graphql_search_api\Utility\SearchAPIHelper;
+use Drupal\search_api\Item\FieldInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -48,21 +49,27 @@ class SearchAPIFieldDeriver extends DeriverBase implements ContainerDeriverInter
     $this->derivatives['index_id']['name'] = 'index_id';
     $this->derivatives['index_id']['type'] = 'String';
 
+    /** @var \Drupal\search_api\IndexInterface $index */
     foreach ($indexes as $index_id => $index) {
+      $parent = str_replace("_", "", ucwords($index_id . "Doc", '_'));
 
       foreach ($index->getFields() as $field_id => $field) {
+        $derivative_id = implode(':', [$parent, $field_id]);
+        if (isset($this->derivatives[$derivative_id])) {
+          $base_plugin_definition['parents'][] = $parent;
+        }
+        else {
+          // Define to which Doc type variant the field belongs to.
+          $base_plugin_definition['parents'] = [$parent];
 
-        // Define to which Doc type variant the field belongs to.
-        $base_plugin_definition['parents'][0] = str_replace("_", "", ucwords($index_id . "Doc", '_'));
+          // Initialising derivative settings.
+          $this->derivatives[$derivative_id] = $base_plugin_definition;
+          $this->derivatives[$derivative_id]['id'] = $field_id;
+          $this->derivatives[$derivative_id]['name'] = $field_id;
 
-        // Initialising derivative settings.
-        $this->derivatives[$field_id] = $base_plugin_definition;
-        $this->derivatives[$field_id]['id'] = $field_id;
-        $this->derivatives[$field_id]['name'] = $field_id;
-
-        // Set field type.
-        $this->setFieldType($field, $field_id);
-
+          // Set field type.
+          $this->setFieldType($field, $derivative_id);
+        }
       }
     }
     return $this->derivatives;
@@ -71,56 +78,56 @@ class SearchAPIFieldDeriver extends DeriverBase implements ContainerDeriverInter
   /**
    * This method maps the field types in Search API to GraphQL types.
    *
-   * @field
+   * @param \Drupal\search_api\Item\FieldInterface $field
    *   The field to map.
-   * @field_id
-   *   The id of the field to map.
+   * @param string $derivative_id
+   *   The id of the field derivative to map.
    */
-  private function setFieldType($field, $field_id) {
+  private function setFieldType(FieldInterface $field, $derivative_id) {
 
     // Get field type.
     $type = $field->getType();
 
     // We can only check if a field is multivalue if it has a Datasource.
-    // @Todo This seems inefficient, check when it's being cached
+    // @todo This seems inefficient, check when it's being cached
     $multivalue = SearchAPIHelper::checkMultivalue($field);
 
     // Map the Search API types to GraphQL.
     switch ($type) {
 
       case  'text':
-        $this->derivatives[$field_id]['type'] = 'String';
+        $this->derivatives[$derivative_id]['type'] = 'String';
         break;
 
       case  'string':
-        $this->derivatives[$field_id]['type'] = 'String';
+        $this->derivatives[$derivative_id]['type'] = 'String';
         break;
 
       case  'boolean':
-        $this->derivatives[$field_id]['type'] = 'Boolean';
+        $this->derivatives[$derivative_id]['type'] = 'Boolean';
         break;
 
       case  'integer':
-        $this->derivatives[$field_id]['type'] = 'Int';
+        $this->derivatives[$derivative_id]['type'] = 'Int';
         break;
 
       case  'decimal':
-        $this->derivatives[$field_id]['type'] = 'Float';
+        $this->derivatives[$derivative_id]['type'] = 'Float';
         break;
 
       case  'date':
-        $this->derivatives[$field_id]['type'] = 'Timestamp';
+        $this->derivatives[$derivative_id]['type'] = 'Timestamp';
         break;
 
       default:
-        $this->derivatives[$field_id]['type'] = 'String';
+        $this->derivatives[$derivative_id]['type'] = 'String';
         break;
 
     }
 
     // If field is multivalue we set the type as an array.
     if ($multivalue) {
-      $this->derivatives[$field_id]['type'] = '[' . $this->derivatives[$field_id]['type'] . ']';
+      $this->derivatives[$derivative_id]['type'] = '[' . $this->derivatives[$derivative_id]['type'] . ']';
     }
   }
 

--- a/src/Plugin/GraphQL/Fields/SearchAPIField.php
+++ b/src/Plugin/GraphQL/Fields/SearchAPIField.php
@@ -22,13 +22,13 @@ class SearchAPIField extends FieldPluginBase {
    * {@inheritdoc}
    */
   public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
-
     $derivative_id = $this->getDerivativeId();
+    list($parent_type, $field_id) = explode(':', $derivative_id);
 
     // Not all documents have values for all fields so we need to check.
-    if (isset($value['item'][$derivative_id])) {
+    if ($parent_type == $info->parentType && isset($value['item'][$field_id])) {
 
-      $field = $value['item'][$derivative_id];
+      $field = $value['item'][$field_id];
 
       $field_values = $field->getValues();
       $field_type = $field->getType();


### PR DESCRIPTION
The field derivatives were being keyed by just the field ID, but those are not unique across indexes, causing collisions. This adds the index ID (as doc type) to the derivative ID to avoid such collisions.