### PR TITLE
Add spellcheck support.

### DIFF
--- a/src/Plugin/GraphQL/Fields/SearchAPISearch.php.orig
+++ b/src/Plugin/GraphQL/Fields/SearchAPISearch.php.orig
@@ -30,7 +30,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *     "range" = "RangeInput",
  *     "sort" = "[SortInput]",
  *     "facets" = "[FacetInput]",
- *     "spellcheck" = "Boolean",
  *     "more_like_this" = "MLTInput",
  *     "solr_params" = "[SolrParameterInput]",
  *   },
@@ -320,11 +319,6 @@ class SearchAPISearch extends FieldPluginBase implements ContainerFactoryPluginI
     if ($args['fulltext']) {
       $this->setFulltextFields($args['fulltext']);
     }
-    if ($args['spellcheck'] && $args['fulltext']) {
-      $this->query->setOption('search_api_spellcheck', [
-        'keys' => $args['fulltext']['keys'],
-      ]);
-    }
     // Adding range parameters to the query (e.g for pagination).
     if ($args['range']) {
       $this->query->range($args['range']['offset'], $args['range']['limit']);
@@ -377,12 +371,6 @@ class SearchAPISearch extends FieldPluginBase implements ContainerFactoryPluginI
     if ($facets) {
       $search_response['facets'] = $facets;
     }
-
-    $spellcheck = $results->getExtraData('search_api_spellcheck');
-    if ($spellcheck && !empty($spellcheck['suggestions'])) {
-      $search_response['spellcheck'] = $spellcheck['suggestions'];
-    }
-
     return $search_response;
   }
 

--- a/src/Plugin/GraphQL/Fields/SearchAPISpellcheck.php
+++ b/src/Plugin/GraphQL/Fields/SearchAPISpellcheck.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\graphql_search_api\Plugin\GraphQL\Fields;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * Solr spellcheck.
+ *
+ * @GraphQLField(
+ *   secure = true,
+ *   parents = {"SearchAPIResult"},
+ *   id = "search_api_spellcheck",
+ *   name = "spellcheck",
+ *   type = "[SearchAPISpellcheck]",
+ * )
+ */
+class SearchAPISpellcheck extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    if (isset($value['spellcheck'])) {
+      foreach ($value['spellcheck'] as $term => $suggestions) {
+
+        // Prepare a facet response.
+        $response_suggestion = NULL;
+        $response_suggestion['type'] = 'SearchAPISpellcheck';
+        $response_suggestion['source'] = $term;
+
+        // Loop through the facet values and load them into the response.
+        foreach ($suggestions as $suggestion) {
+          $response_suggestion['suggestion'] = $suggestion;
+          yield $response_suggestion;
+        }
+      }
+    }
+  }
+
+}

--- a/src/Plugin/GraphQL/Fields/SearchAPISpellcheckSource.php
+++ b/src/Plugin/GraphQL/Fields/SearchAPISpellcheckSource.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\graphql_search_api\Plugin\GraphQL\Fields;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * Search API spellcheck source.
+ *
+ * @GraphQLField(
+ *   secure = true,
+ *   parents = {"SearchAPISpellcheck"},
+ *   id = "search_api_spellcheck_source",
+ *   name = "source",
+ *   type = "String"
+ * )
+ */
+class SearchAPISpellcheckSource extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    yield $value['source'];
+  }
+
+}

--- a/src/Plugin/GraphQL/Fields/SearchAPISpellcheckSuggestion.php
+++ b/src/Plugin/GraphQL/Fields/SearchAPISpellcheckSuggestion.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\graphql_search_api\Plugin\GraphQL\Fields;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * Search API spellcheck suggestion.
+ *
+ * @GraphQLField(
+ *   secure = true,
+ *   parents = {"SearchAPISpellcheck"},
+ *   id = "search_api_spellcheck_suggestion",
+ *   name = "suggestion",
+ *   type = "String"
+ * )
+ */
+class SearchAPISpellcheckSuggestion extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    yield $value['suggestion'];
+  }
+
+}

--- a/src/Plugin/GraphQL/Types/SearchAPISpellcheck.php
+++ b/src/Plugin/GraphQL/Types/SearchAPISpellcheck.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\graphql_search_api\Plugin\GraphQL\Types;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Types\TypePluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * Solr spellcheck.
+ *
+ * @GraphQLType(
+ *   id = "spellcheck",
+ *   name = "SearchAPISpellcheck",
+ * )
+ */
+class SearchAPISpellcheck extends TypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($object, ResolveContext $context, ResolveInfo $info) {
+    return $object['type'] == 'SearchAPISpellcheck';
+  }
+
+}


### PR DESCRIPTION
This takes the approach to make it as simple as possible to get spellcheck suggestions on the query, by only adding a boolean to the query parameters and automatically forwarding the full text search keys to Search API. There's also at most one result returned for each search term.

Setting the option when using a search backend that doesn't support spellcheck will only lead to no spellcheck result being returned.